### PR TITLE
[bug] allow null value in reference field

### DIFF
--- a/subscription/models/subscription.py
+++ b/subscription/models/subscription.py
@@ -87,7 +87,6 @@ class Subscription(models.Model):
         string='Status', copy=False, default='draft', tracking=True)
     doc_source = fields.Reference(
         selection=_get_document_types, string='Source Document',
-        required=True,
         help="User can choose the source document on which he wants to create "
         "documents")
     doc_lines = fields.One2many(


### PR DESCRIPTION
When you delete a record used in a reference field, Odoo can't handle this record and raise an error. 
To allow to fix this issue by using overhide of unlink on sale order, we need to be able top put the suscription.suibscription.doc_source to None.